### PR TITLE
Add `removeGridComponent`

### DIFF
--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -18,7 +18,7 @@ import layout from './layout.json';
 const handleClass = 'demo-handle';
 
 function Block(props) {
-  const { text, onReady } = props;
+  const { text, onReady, clearComponent } = props;
   onReady();
   /*
     onReady is useful when we want the VitessceGrid parent to be able to send
@@ -33,6 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
+      <button onClick={clearComponent}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -18,7 +18,7 @@ import layout from './layout.json';
 const handleClass = 'demo-handle';
 
 function Block(props) {
-  const { text, onReady, clearComponent } = props;
+  const { text, onReady, removeGridComponent } = props;
   onReady();
   /*
     onReady is useful when we want the VitessceGrid parent to be able to send
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button type="button" onClick={() => { console.warn('clearComponent!'); clearComponent(); }}>Close</button>
+      <button type="button" onClick={() => { console.warn('removeGridComponent!'); removeGridComponent(); }}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button type="button" onClick={clearComponent}>Close</button>
+      <button type="button" onClick={() => { console.warn('clearComponent!'); clearComponent(); }}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button onClick={clearComponent}>Close</button>
+      <button type="button" onClick={clearComponent}>Close</button>
     </div>
   );
 }

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -62,6 +62,7 @@ const VitessceGrid = (props) => {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
 
+  // eslint-disable-next-line no-unused-vars
   const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const [gridComponents, setGridComponents] = useState(components);
 
@@ -76,7 +77,7 @@ const VitessceGrid = (props) => {
           ${draggableHandle}:active {
             cursor: grabbing;
           }
-        `}
+          `}
     </style>
   );
 

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Responsive, WidthProvider } from 'react-grid-layout';
 
@@ -19,8 +19,7 @@ function shallowEqual(objA, objB) {
     return false;
   }
 
-  for (let idx = 0; idx < keysA.length; idx++) { // eslint-disable-line no-plusplus
-    const key = keysA[idx];
+  for (const key of keysA) { // eslint-disable-line no-restricted-syntax
     if (!Object.prototype.hasOwnProperty.call(objB, key)) {
       return false;
     }
@@ -62,7 +61,7 @@ const VitessceGridComponent = ({
   );
 };
 
-const VitessceGrid = React.memo((props) => {
+const VitessceGrid = (props) => {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
@@ -88,18 +87,22 @@ const VitessceGrid = React.memo((props) => {
     </style>
   );
 
+  // useMemo(() => {
+  //   if (readyComponentKeys.size === Object.keys(components).length) {
+  //   // The sets are now equal.
+  //     onAllReady();
+  //   }
+  // }, [components, onAllReady, readyComponentKeys]);
+
   const layoutChildren = Object.entries(components).map(([k, v]) => {
     const Component = getComponent(v.component);
-    const onReady = () => { console.log('yo'); };
-    // {
-    //   const newReadyComponentKeys = new Set(readyComponentKeys);
-    //   newReadyComponentKeys.add(k);
-    //   if (newReadyComponentKeys.size === Object.keys(components).length) {
-    //     // The sets are now equal.
-    //     onAllReady();
-    //   }
-    //   setReadyComponentKeys(newReadyComponentKeys);
-    // };
+    const onReady = () => {
+      // const newReadyComponentKeys = new Set(readyComponentKeys);
+      // newReadyComponentKeys.add(k);
+      // setReadyComponentKeys(newReadyComponentKeys);
+      console.log('hi');
+    };
+
     return VitessceGridComponent({
       k, v, Component, onReady,
     });
@@ -129,7 +132,7 @@ const VitessceGrid = React.memo((props) => {
       </ResponsiveGridLayout>
     </React.Fragment>
   );
-}, (prevProps, nextProps) => !shallowEqual(prevProps, nextProps));
+};
 
 VitessceGrid.defaultProps = {
   padding: 10,
@@ -137,4 +140,4 @@ VitessceGrid.defaultProps = {
   onAllReady: () => {},
 };
 
-export default VitessceGrid;
+export default React.memo(VitessceGrid, !shallowEqual);

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import { Responsive, WidthProvider } from 'react-grid-layout';
 
@@ -44,6 +44,7 @@ const VitessceGridComponent = ({
   k, v, Component, onReady,
 }) => {
   const [showComponent, setShowComponent] = useState(true);
+
   return (
     <div key={k}>
       {
@@ -87,20 +88,17 @@ const VitessceGrid = (props) => {
     </style>
   );
 
-  // useMemo(() => {
-  //   if (readyComponentKeys.size === Object.keys(components).length) {
-  //   // The sets are now equal.
-  //     onAllReady();
-  //   }
-  // }, [components, onAllReady, readyComponentKeys]);
-
   const layoutChildren = Object.entries(components).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
-      // const newReadyComponentKeys = new Set(readyComponentKeys);
-      // newReadyComponentKeys.add(k);
-      // setReadyComponentKeys(newReadyComponentKeys);
-      console.log('hi');
+      setReadyComponentKeys((prevReadyComponentKeys) => {
+        prevReadyComponentKeys.add(k);
+        if (prevReadyComponentKeys.size === Object.keys(components).length) {
+          // The sets are now equal
+          onAllReady();
+        }
+        return prevReadyComponentKeys;
+      });
     };
 
     return VitessceGridComponent({

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -41,37 +41,29 @@ function shallowEqual(objA, objB) {
 }
 
 const VitessceGridComponent = ({
-  k, v, Component, onReady,
-}) => {
-  const [showComponent, setShowComponent] = useState(true);
-
-  return (
-    <div key={k}>
-      {
-      showComponent
-        ? (
-          <Component
-            {... v.props}
-            clearComponent={() => setShowComponent(false)}
-            onReady={onReady}
-          />
-        )
-        : null
-      }
-    </div>
-  );
-};
+  k, v, Component, onReady, removeGridComponent,
+}) => (
+  <div key={k}>
+    <Component
+      {... v.props}
+      clearComponent={removeGridComponent}
+      onReady={onReady}
+    />
+  </div>
+);
 
 const VitessceGrid = (props) => {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
   } = props;
-  const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const ResponsiveGridLayout = WidthProvider(Responsive);
   const {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
+
+  const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
+  const [gridComponents, setGridComponents] = useState(components);
 
   // Inline CSS is generally avoided, but this saves the end-user a little work,
   // and prevents class names from getting out of sync.
@@ -88,12 +80,12 @@ const VitessceGrid = (props) => {
     </style>
   );
 
-  const layoutChildren = Object.entries(components).map(([k, v]) => {
+  const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
       setReadyComponentKeys((prevReadyComponentKeys) => {
         prevReadyComponentKeys.add(k);
-        if (prevReadyComponentKeys.size === Object.keys(components).length) {
+        if (prevReadyComponentKeys.size === Object.keys(gridComponents).length) {
           // The sets are now equal
           onAllReady();
         }
@@ -101,8 +93,13 @@ const VitessceGrid = (props) => {
       });
     };
 
+    const removeGridComponent = () => {
+      const { [k]: _, ...newGridComponents } = gridComponents;
+      setGridComponents(newGridComponents);
+    };
+
     return VitessceGridComponent({
-      k, v, Component, onReady,
+      k, v, Component, onReady, removeGridComponent,
     });
   });
 


### PR DESCRIPTION
Fixes #7. Adds `clearComponent` prop to `Component` which allows us to remove a pane from `VitessceGrid`. Now React will handle all "cleanup" lifecycle hooks.  