### PR TITLE
Mccalluc/clear component hopefully

### DIFF
--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -18,7 +18,7 @@ import layout from './layout.json';
 const handleClass = 'demo-handle';
 
 function Block(props) {
-  const { text, onReady } = props;
+  const { text, onReady, clearComponent } = props;
   onReady();
   /*
     onReady is useful when we want the VitessceGrid parent to be able to send
@@ -33,6 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
+      <button onClick={clearComponent}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -18,7 +18,7 @@ import layout from './layout.json';
 const handleClass = 'demo-handle';
 
 function Block(props) {
-  const { text, onReady, clearComponent } = props;
+  const { text, onReady, removeGridComponent } = props;
   onReady();
   /*
     onReady is useful when we want the VitessceGrid parent to be able to send
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button type="button" onClick={() => { console.warn('clearComponent!'); clearComponent(); }}>Close</button>
+      <button type="button" onClick={() => { console.warn('removeGridComponent!'); removeGridComponent(); }}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button type="button" onClick={clearComponent}>Close</button>
+      <button type="button" onClick={() => { console.warn('clearComponent!'); clearComponent(); }}>Close</button>
     </div>
   );
 }

--- a/demo/src/renderDemo.js
+++ b/demo/src/renderDemo.js
@@ -33,7 +33,7 @@ function Block(props) {
     <div style={{ height: '100%', width: '100%', border: '2px solid black' }}>
       <div className={handleClass}>drag-me</div>
       <div>{text}</div>
-      <button onClick={clearComponent}>Close</button>
+      <button type="button" onClick={clearComponent}>Close</button>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vitessce-grid",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2678,6 +2678,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -5461,6 +5462,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       },
@@ -5469,7 +5471,8 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5669,7 +5672,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -6040,7 +6044,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6061,12 +6066,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6081,17 +6088,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6208,7 +6218,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6220,6 +6231,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6234,6 +6246,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -6241,12 +6254,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6265,6 +6280,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6345,7 +6361,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6357,6 +6374,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6442,7 +6460,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6478,6 +6497,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6497,6 +6517,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6540,12 +6561,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8872,6 +8895,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -11126,7 +11150,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11147,12 +11172,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11167,17 +11194,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11294,7 +11324,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11306,6 +11337,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11320,6 +11352,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11327,12 +11360,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -11351,6 +11386,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11431,7 +11467,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11443,6 +11480,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11528,7 +11566,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11564,6 +11603,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11583,6 +11623,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11626,12 +11667,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12406,6 +12449,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -12416,6 +12460,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -12424,7 +12469,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12762,6 +12808,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -12771,7 +12818,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -12784,6 +12832,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -12794,6 +12843,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -13348,7 +13398,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -14438,7 +14489,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14459,12 +14511,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14479,17 +14533,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14606,7 +14663,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14618,6 +14676,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14632,6 +14691,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14639,12 +14699,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14663,6 +14725,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14743,7 +14806,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14755,6 +14819,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14840,7 +14905,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14876,6 +14942,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14895,6 +14962,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14938,12 +15006,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16174,13 +16244,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -16191,7 +16263,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -16199,7 +16272,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -17538,13 +17612,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -17577,7 +17653,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "noop2": {
       "version": "2.0.0",
@@ -25031,13 +25108,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
       "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -25351,6 +25430,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
       "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -25361,6 +25441,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
       "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -26536,7 +26617,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -13,7 +13,8 @@ export default function VitessceGrid(props) {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
 
-  const readyComponentKeys = new Set(); // only created when props change due to React.Memo
+  // eslint-disable-next-line no-unused-vars
+  const [_readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const [gridComponents, setGridComponents] = useState(components);
 
   // Inline CSS is generally avoided, but this saves the end-user a little work,
@@ -34,16 +35,17 @@ export default function VitessceGrid(props) {
   const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
-      readyComponentKeys.add(k);
-      if (readyComponentKeys.size === Object.keys(gridComponents).length) {
-        // The sets are now equal
-        onAllReady();
-      }
+      setReadyComponentKeys((prevReadyComponentKeys) => {
+        prevReadyComponentKeys.add(k);
+        if (prevReadyComponentKeys.size === Object.keys(gridComponents).length) {
+          // The sets are now equal.
+          onAllReady();
+        }
+        return prevReadyComponentKeys;
+      });
     };
 
     const removeGridComponent = () => {
-      // delete gridComponents[k];
-      // setGridComponents(gridComponents);
       const newGridComponents = { ...gridComponents };
       delete newGridComponents[k];
       setGridComponents(newGridComponents);

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -62,6 +62,7 @@ const VitessceGrid = (props) => {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
 
+  // eslint-disable-next-line no-unused-vars
   const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const [gridComponents, setGridComponents] = useState(components);
 
@@ -76,7 +77,7 @@ const VitessceGrid = (props) => {
           ${draggableHandle}:active {
             cursor: grabbing;
           }
-        `}
+          `}
     </style>
   );
 

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Responsive, WidthProvider } from 'react-grid-layout';
 
@@ -19,8 +19,7 @@ function shallowEqual(objA, objB) {
     return false;
   }
 
-  for (let idx = 0; idx < keysA.length; idx++) { // eslint-disable-line no-plusplus
-    const key = keysA[idx];
+  for (const key of keysA) { // eslint-disable-line no-restricted-syntax
     if (!Object.prototype.hasOwnProperty.call(objB, key)) {
       return false;
     }
@@ -62,7 +61,7 @@ const VitessceGridComponent = ({
   );
 };
 
-const VitessceGrid = React.memo((props) => {
+const VitessceGrid = (props) => {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
@@ -88,18 +87,22 @@ const VitessceGrid = React.memo((props) => {
     </style>
   );
 
+  // useMemo(() => {
+  //   if (readyComponentKeys.size === Object.keys(components).length) {
+  //   // The sets are now equal.
+  //     onAllReady();
+  //   }
+  // }, [components, onAllReady, readyComponentKeys]);
+
   const layoutChildren = Object.entries(components).map(([k, v]) => {
     const Component = getComponent(v.component);
-    const onReady = () => { console.log('yo'); };
-    // {
-    //   const newReadyComponentKeys = new Set(readyComponentKeys);
-    //   newReadyComponentKeys.add(k);
-    //   if (newReadyComponentKeys.size === Object.keys(components).length) {
-    //     // The sets are now equal.
-    //     onAllReady();
-    //   }
-    //   setReadyComponentKeys(newReadyComponentKeys);
-    // };
+    const onReady = () => {
+      // const newReadyComponentKeys = new Set(readyComponentKeys);
+      // newReadyComponentKeys.add(k);
+      // setReadyComponentKeys(newReadyComponentKeys);
+      console.log('hi');
+    };
+
     return VitessceGridComponent({
       k, v, Component, onReady,
     });
@@ -129,7 +132,7 @@ const VitessceGrid = React.memo((props) => {
       </ResponsiveGridLayout>
     </React.Fragment>
   );
-}, (prevProps, nextProps) => !shallowEqual(prevProps, nextProps));
+};
 
 VitessceGrid.defaultProps = {
   padding: 10,
@@ -137,4 +140,4 @@ VitessceGrid.defaultProps = {
   onAllReady: () => {},
 };
 
-export default VitessceGrid;
+export default React.memo(VitessceGrid, !shallowEqual);

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import { Responsive, WidthProvider } from 'react-grid-layout';
 
@@ -44,6 +44,7 @@ const VitessceGridComponent = ({
   k, v, Component, onReady,
 }) => {
   const [showComponent, setShowComponent] = useState(true);
+
   return (
     <div key={k}>
       {
@@ -87,20 +88,17 @@ const VitessceGrid = (props) => {
     </style>
   );
 
-  // useMemo(() => {
-  //   if (readyComponentKeys.size === Object.keys(components).length) {
-  //   // The sets are now equal.
-  //     onAllReady();
-  //   }
-  // }, [components, onAllReady, readyComponentKeys]);
-
   const layoutChildren = Object.entries(components).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
-      // const newReadyComponentKeys = new Set(readyComponentKeys);
-      // newReadyComponentKeys.add(k);
-      // setReadyComponentKeys(newReadyComponentKeys);
-      console.log('hi');
+      setReadyComponentKeys((prevReadyComponentKeys) => {
+        prevReadyComponentKeys.add(k);
+        if (prevReadyComponentKeys.size === Object.keys(components).length) {
+          // The sets are now equal
+          onAllReady();
+        }
+        return prevReadyComponentKeys;
+      });
     };
 
     return VitessceGridComponent({

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -4,43 +4,43 @@ import { Responsive, WidthProvider } from 'react-grid-layout';
 
 import { getMaxRows, resolveLayout } from './layoutUtils';
 
-function shallowEqual(objA, objB) {
-  // Taken from "shallowequal" on NPM, with modifications.
-  if (objA === objB) {
-    return true;
-  }
-  if (typeof objA !== 'object' || !objA || typeof objB !== 'object' || !objB) {
-    return false;
-  }
+// function shallowEqual(objA, objB) {
+//   // Taken from "shallowequal" on NPM, with modifications.
+//   if (objA === objB) {
+//     return true;
+//   }
+//   if (typeof objA !== 'object' || !objA || typeof objB !== 'object' || !objB) {
+//     return false;
+//   }
+//
+//   const keysA = Object.keys(objA);
+//   const keysB = Object.keys(objB);
+//   if (keysA.length !== keysB.length) {
+//     return false;
+//   }
+//
+//   keysA.forEach((key) => { // eslint-disable-line consistent-return
+//     if (!Object.prototype.hasOwnProperty.call(objB, key)) {
+//       return false;
+//     }
+//     if (key === 'onAllReady') {
+//       return true;
+//       // TODO: We were stuck in an infinite loop because the fuctions were not equal.
+//       // This is a hack.
+//     }
+//
+//     const valueA = objA[key];
+//     const valueB = objB[key];
+//
+//     if (valueA !== valueB) {
+//       return false;
+//     }
+//   });
+//
+//   return true;
+// }
 
-  const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-
-  keysA.forEach((key) => { // eslint-disable-line consistent-return
-    if (!Object.prototype.hasOwnProperty.call(objB, key)) {
-      return false;
-    }
-    if (key === 'onAllReady') {
-      return true;
-      // TODO: We were stuck in an infinite loop because the fuctions were not equal.
-      // This is a hack.
-    }
-
-    const valueA = objA[key];
-    const valueB = objB[key];
-
-    if (valueA !== valueB) {
-      return false;
-    }
-  });
-
-  return true;
-}
-
-const VitessceGrid = (props) => {
+export default function VitessceGrid(props) {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
@@ -69,6 +69,7 @@ const VitessceGrid = (props) => {
   );
 
   const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
+    console.log('layoutChildren', k, v);
     const Component = getComponent(v.component);
     const onReady = () => {
       readyComponentKeys.add(k);
@@ -79,6 +80,8 @@ const VitessceGrid = (props) => {
     };
 
     const removeGridComponent = () => {
+      // delete gridComponents[k];
+      // setGridComponents(gridComponents);
       const newGridComponents = { ...gridComponents };
       delete newGridComponents[k];
       setGridComponents(newGridComponents);
@@ -126,7 +129,7 @@ VitessceGrid.defaultProps = {
   onAllReady: () => {},
 };
 
-export default React.memo(
-  VitessceGrid,
-  (prevProps, nextProps) => !shallowEqual(prevProps, nextProps),
-);
+// export default React.memo(
+//   VitessceGrid,
+//   (prevProps, nextProps) => !shallowEqual(prevProps, nextProps),
+// );

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -35,7 +35,7 @@ export default function VitessceGrid(props) {
     const Component = getComponent(v.component);
     const onReady = () => {
       readyComponentKeys.add(k);
-      if (readyComponentKeys === Object.keys(gridComponents).length) {
+      if (readyComponentKeys.size === Object.keys(gridComponents).length) {
         // The sets are now equal
         onAllReady();
       }

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -32,7 +32,6 @@ export default function VitessceGrid(props) {
   );
 
   const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
-    console.log('layoutChildren', k, v);
     const Component = getComponent(v.component);
     const onReady = () => {
       readyComponentKeys.add(k);
@@ -84,7 +83,7 @@ export default function VitessceGrid(props) {
       </ResponsiveGridLayout>
     </React.Fragment>
   );
-};
+}
 
 VitessceGrid.defaultProps = {
   padding: 10,

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -1,51 +1,14 @@
 import React, { useState } from 'react';
-
 import { Responsive, WidthProvider } from 'react-grid-layout';
-
 import { getMaxRows, resolveLayout } from './layoutUtils';
 
-// function shallowEqual(objA, objB) {
-//   // Taken from "shallowequal" on NPM, with modifications.
-//   if (objA === objB) {
-//     return true;
-//   }
-//   if (typeof objA !== 'object' || !objA || typeof objB !== 'object' || !objB) {
-//     return false;
-//   }
-//
-//   const keysA = Object.keys(objA);
-//   const keysB = Object.keys(objB);
-//   if (keysA.length !== keysB.length) {
-//     return false;
-//   }
-//
-//   keysA.forEach((key) => { // eslint-disable-line consistent-return
-//     if (!Object.prototype.hasOwnProperty.call(objB, key)) {
-//       return false;
-//     }
-//     if (key === 'onAllReady') {
-//       return true;
-//       // TODO: We were stuck in an infinite loop because the fuctions were not equal.
-//       // This is a hack.
-//     }
-//
-//     const valueA = objA[key];
-//     const valueB = objB[key];
-//
-//     if (valueA !== valueB) {
-//       return false;
-//     }
-//   });
-//
-//   return true;
-// }
+const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export default function VitessceGrid(props) {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
   } = props;
-  const ResponsiveGridLayout = WidthProvider(Responsive);
   const {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
@@ -128,8 +91,3 @@ VitessceGrid.defaultProps = {
   margin: 10,
   onAllReady: () => {},
 };
-
-// export default React.memo(
-//   VitessceGrid,
-//   (prevProps, nextProps) => !shallowEqual(prevProps, nextProps),
-// );

--- a/src/VitessceGrid.js
+++ b/src/VitessceGrid.js
@@ -41,37 +41,29 @@ function shallowEqual(objA, objB) {
 }
 
 const VitessceGridComponent = ({
-  k, v, Component, onReady,
-}) => {
-  const [showComponent, setShowComponent] = useState(true);
-
-  return (
-    <div key={k}>
-      {
-      showComponent
-        ? (
-          <Component
-            {... v.props}
-            clearComponent={() => setShowComponent(false)}
-            onReady={onReady}
-          />
-        )
-        : null
-      }
-    </div>
-  );
-};
+  k, v, Component, onReady, removeGridComponent,
+}) => (
+  <div key={k}>
+    <Component
+      {... v.props}
+      clearComponent={removeGridComponent}
+      onReady={onReady}
+    />
+  </div>
+);
 
 const VitessceGrid = (props) => {
   const {
     layout, getComponent, padding, margin, draggableHandle,
     reactGridLayoutProps, onAllReady, rowHeight,
   } = props;
-  const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const ResponsiveGridLayout = WidthProvider(Responsive);
   const {
     cols, layouts, breakpoints, components,
   } = resolveLayout(layout);
+
+  const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
+  const [gridComponents, setGridComponents] = useState(components);
 
   // Inline CSS is generally avoided, but this saves the end-user a little work,
   // and prevents class names from getting out of sync.
@@ -88,12 +80,12 @@ const VitessceGrid = (props) => {
     </style>
   );
 
-  const layoutChildren = Object.entries(components).map(([k, v]) => {
+  const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
       setReadyComponentKeys((prevReadyComponentKeys) => {
         prevReadyComponentKeys.add(k);
-        if (prevReadyComponentKeys.size === Object.keys(components).length) {
+        if (prevReadyComponentKeys.size === Object.keys(gridComponents).length) {
           // The sets are now equal
           onAllReady();
         }
@@ -101,8 +93,13 @@ const VitessceGrid = (props) => {
       });
     };
 
+    const removeGridComponent = () => {
+      const { [k]: _, ...newGridComponents } = gridComponents;
+      setGridComponents(newGridComponents);
+    };
+
     return VitessceGridComponent({
-      k, v, Component, onReady,
+      k, v, Component, onReady, removeGridComponent,
     });
   });
 


### PR DESCRIPTION
Replace #8.

It took me nearly the whole day to see it, but the problem was with `ResponsiveGridLayout = WidthProvider(Responsive)` *inside* the definition for `VitessceGrid`. I was comparing the React Profiler output for vitessce-grid and the RGL demo. (This required checking out the repo and making a config tweak: React dev tools don't work with production builds.) For us (but not for them) `WidthProvider` was rendering from scratch every time, and that meant everything below was being re-rendered from scratch, too: Matching IDs weren't helping us. I'm not sure why it was inside the function to begin with... not going to go into the git archaeology, but it may have started life as a class, and since objects have a duration, the inner definition might not have been a problem?

I'm also removing the memo code... Unless I'm missing something, React memo is just an optimization -- It shouldn't change the end behavior -- and here it's not in a tight loop, and it added a lot of complexity.